### PR TITLE
Fix collections load

### DIFF
--- a/src/store/modules/collections.js
+++ b/src/store/modules/collections.js
@@ -91,12 +91,7 @@ export default {
       { collection_id, data }
     ) {
       if (validateID(collection_id) && validateParams(data)) {
-        const material = await this.$axios.$post(
-          `collections/${collection_id}/materials/`,
-          data
-        );
-        commit('SET_MATERIAL_TO_COLLECTION', material);
-        return data;
+        await this.$axios.$post(`collections/${collection_id}/materials/`, data);
       } else {
         $log.error('Validate error: ', { collection_id, data });
       }


### PR DESCRIPTION
That nasty bug where only a reload would fix the materials. Materials were loading fine, but before that we were dealing with some malicious material injection into the store that got loaded first (because no requests are made for reading from the store)